### PR TITLE
add type, deprecation, and profile link attributes

### DIFF
--- a/hal.js
+++ b/hal.js
@@ -10,8 +10,18 @@
   function isString(value) {
     return typeof value === 'string';
   }
+
   var linkAttributes = ['href', 'templated', 'type',
     'deprecation', 'name', 'profile', 'title', 'hreflang'];
+
+  /**
+   * Test if a name is a valid link attribute.
+   * @param  String attr → name of attribute to check
+   * @return Boolean → true if attr refers to a link attribute, else false
+   */
+  function isLinkAttribute(attr) {
+    return linkAttributes.indexOf(attr) != -1;
+  }
 
   /**
    * Link to another hypermedia
@@ -33,7 +43,7 @@
       if (!value.href) throw new Error('Required <link> attribute "href"');
       for (var attr in value) {
         if (value.hasOwnProperty(attr)) {
-          if (attr === 'rel' || ~linkAttributes.indexOf(attr)) {
+          if (attr === 'rel' || isLinkAttribute(attr)) {
             this[attr] = value[attr];
           }
         }

--- a/hal.js
+++ b/hal.js
@@ -10,6 +10,8 @@
   function isString(value) {
     return typeof value === 'string';
   }
+  var linkAttributes = ['href', 'templated', 'type',
+    'deprecation', 'name', 'profile', 'title', 'hreflang'];
 
   /**
    * Link to another hypermedia
@@ -29,14 +31,11 @@
 
       // If value is a hashmap, just copy properties
       if (!value.href) throw new Error('Required <link> attribute "href"');
-      var expectedAttributes = ['rel', 'href', 'name', 'hreflang', 'title', 'templated'];
       for (var attr in value) {
         if (value.hasOwnProperty(attr)) {
-          if (!~expectedAttributes.indexOf(attr)) {
-            // Unexpected attribute: ignore it
-            continue;
+          if (attr === 'rel' || ~linkAttributes.indexOf(attr)) {
+            this[attr] = value[attr];
           }
-          this[attr] = value[attr];
         }
       }
 
@@ -73,7 +72,7 @@
 
     // Note: calling "JSON.stringify(this)" will fail as JSON.stringify itself calls toJSON()
     // We need to copy properties to a new object
-    return ['href', 'name', 'hreflang', 'title', 'templated'].reduce(function (object, key) {
+    return linkAttributes.reduce(function (object, key) {
       if (link[key]) {
         object[key] = link[key];
       }

--- a/test/hal.js
+++ b/test/hal.js
@@ -31,6 +31,26 @@ describe('HAL', function () {
       expect(link.href).to.equal('href');
       expect(link.hello).to.be.undefined;
     });
+    it('should accept all specced attributes', function () {
+      var link = new hal.Link('rel', {
+        href: 'href',
+        templated: 'templated',
+        type: 'type',
+        deprecation: 'deprecation',
+        name: 'name',
+        profile: 'profile',
+        title: 'title',
+        hreflang: 'hreflang'
+      });
+      expect(link.href).to.equal('href');
+      expect(link.templated).to.equal('templated');
+      expect(link.type).to.equal('type');
+      expect(link.deprecation).to.equal('deprecation');
+      expect(link.name).to.equal('name');
+      expect(link.profile).to.equal('profile');
+      expect(link.title).to.equal('title');
+      expect(link.hreflang).to.equal('hreflang');
+    });
   });
 
   describe('Resource', function () {
@@ -179,6 +199,15 @@ describe('HAL', function () {
             { href: '/user/jane' },
             { href: '/user/joe' }
           ]
+        });
+      });
+
+      it('link includes type attribute if it exists', function() {
+        var res = hal.Resource({}, '/self/href');
+        res.link('image', { href: '/plot.png', type: 'plot' });
+        expect(res.toJSON()._links).to.deep.equal({
+          self: { href: '/self/href' },
+          image:{ href: '/plot.png', type: 'plot' }
         });
       });
     });


### PR DESCRIPTION
All link properties from the spec:

  https://tools.ietf.org/html/draft-kelly-json-hal-06#section-5

are now included.

Added test for Link attributes and JSON rendering of link with `type`.